### PR TITLE
Remove hidden SEO blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -863,13 +863,7 @@
         <h2>Featured Projects</h2>
         <p>A selection of impactful projects spanning enterprise platforms, open source contributions, and innovative solutions:</p>
         
-        <!-- Hidden SEO content for search engines -->
-        <div style="position: absolute; left: -9999px; top: -9999px; visibility: hidden;" aria-hidden="true">
-          <span>Golang projects, Go development projects, Go backend systems, Go microservices projects,
-          Go application development, Golang enterprise projects, Go web applications, Go API development,
-          Go performance optimization projects, Go distributed systems, Go cloud applications,
-          professional Golang developer portfolio, Go developer work examples, Golang development experience.</span>
-        </div>
+        <p>These projects showcase my Golang expertise across backend systems, microservices, web APIs, and cloud applications.</p>
         <div class="project-grid">
           <div class="project-card">
             <h4>Klink.Cloud Contact Center Platform</h4>
@@ -1010,13 +1004,7 @@
         <h2>Open Source</h2>
         <p>Contributing to the developer community with innovative tools and libraries:</p>
         
-        <!-- Hidden SEO content for search engines -->
-        <div style="position: absolute; left: -9999px; top: -9999px; visibility: hidden;" aria-hidden="true">
-          <span>Go open source projects, Golang libraries, Go packages, Go development tools,
-          Go community contributions, Golang open source developer, Go library author,
-          Go package maintainer, Go development contributions, Golang GitHub projects,
-          open source Go developer, Go programming contributions, Golang ecosystem contributions.</span>
-        </div>
+          <p>My open source work includes maintaining Golang libraries, packages, and development tools for the community.</p>
         <div class="project-grid">
           <div class="project-card">
             <h4>Starlight EPUB Viewer</h4>
@@ -1154,14 +1142,8 @@
       <section id="experience" aria-label="Work experience">
         <h2>Experience</h2>
         <p>Professional journey across leading technology companies, building scalable systems and leading development teams:</p>
+          <p>As a senior Golang developer, I have led teams and built enterprise-grade backend systems and commercial projects.</p>
         
-        <!-- Hidden SEO content for search engines -->
-        <div style="position: absolute; left: -9999px; top: -9999px; visibility: hidden;" aria-hidden="true">
-          <span>Golang developer experience, Go developer career, Go backend engineer experience,
-          professional Golang developer background, Go development expertise, senior Go developer experience,
-          Golang engineer work history, Go developer employment, Go programming experience,
-          enterprise Go development, commercial Go projects, Go development leadership.</span>
-        </div>
         <h3>
           <a
             href="https://klink.cloud"


### PR DESCRIPTION
## Summary
- remove hidden SEO divs that were positioned off-screen
- replace them with visible paragraphs describing the same content

## Testing
- `grep -n "position: absolute; left: -9999px" index.html`

------
https://chatgpt.com/codex/tasks/task_e_687489ae3f608320a700470201e1ca18